### PR TITLE
Proposed fix for #8 - link problems

### DIFF
--- a/templates/node.html.twig
+++ b/templates/node.html.twig
@@ -10,7 +10,7 @@
     {{ title_prefix }}
     {% if not page %}
       <h2{{ title_attributes }}>
-        <a href="{{ node_url }}">{{ label }}</a>
+        <a href="{{ url }}">{{ label }}</a>
       </h2>
     {% endif %}
     {{ title_suffix }}


### PR DESCRIPTION
`{{ node_url }}` has been changed to just `{{ url }}`.  Tested with D8-Alpha15. 

As for the site link title issue, most likely the user needs to clear their cache. I tested a hard coded site title and it rendered fine after a cache clear. 
